### PR TITLE
Remove NASAHubble from space channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,6 @@ func run(c *cli.Context) error {
 			"921111554371682304":  "artfolio",       // @DrawnDavidson
 			"1581511":             "wwdc",           // @macrumorslive
 			"29472803":            "final-frontier", // @NASAWebb
-			"14091091":            "final-frontier", // @NASAHubble
 			"18831926":            "covid19-feed",   // @DrEricDing
 			"88589013":            "covid19-feed",   //@fitterhappierAJ
 			"920943710254313472":  "covid19-feed",   //@dgurdasani1


### PR DESCRIPTION
It produces a lot of chatter.